### PR TITLE
fix: Update ColorInput.vue to handle color input formatting

### DIFF
--- a/app/components/ColorInput.vue
+++ b/app/components/ColorInput.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { random } from '@ctrl/tinycolor';
 
-const color = defineModel<string>();
+const color = defineModel<string>({
+  set: (v) => (v.length === 6 && !v.startsWith('#') ? `#${v}` : v),
+});
 
 defineProps<{
   label?: string;


### PR DESCRIPTION
The ColorInput.vue component has been updated to handle the formatting of color inputs. Previously, the color model would accept both 6-digit hexadecimal values and values without the '#' prefix. Now, the set function has been modified to automatically add the '#' prefix if the input value is 6 digits long and does not already start with '#'. This ensures consistent formatting of color inputs.

Refactor the ColorInput.vue component to handle color input formatting.